### PR TITLE
refactor: use new pak.json format for providing pak information

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Pak Name
         id: pak-name
         run: |
-          echo "PAK_NAME=$(jq -r .label config.json)" >> $GITHUB_OUTPUT
+          echo "PAK_NAME=$(jq -r .name pak.json)" >> $GITHUB_OUTPUT
 
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v2.2.3
@@ -64,14 +64,14 @@ jobs:
       - name: Get Pak Name
         id: pak-name
         run: |
-          echo "PAK_NAME=$(jq -r .label config.json)" >> $GITHUB_OUTPUT
+          echo "PAK_NAME=$(jq -r .name pak.json)" >> $GITHUB_OUTPUT
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4.2.1
         with:
           name: "${{ steps.pak-name.outputs.PAK_NAME }}.pak.zip"
           path: "dist"
-      
+
       - name: Validate Artifact exists
         run: |
           if [ ! -f "dist/${{ steps.pak-name.outputs.PAK_NAME }}.pak.zip" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,8 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-24.04-arm
+    outputs:
+      next-tag: ${{ steps.next-tag.outputs.version }}
 
     steps:
       - name: Checkout
@@ -36,13 +38,27 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3.10.0
 
+      - name: Get Latest Tag
+        id: latest-tag
+        run: |
+          echo GIT_LATEST_TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)")" >>"$GITHUB_OUTPUT"
+
+      - name: Compute Next Tag
+        id: next-tag
+        uses: docker://ghcr.io/dokku/semver-generator:latest
+        with:
+          bump: ${{ github.event.inputs.bump_type }}
+          input: ${{ steps.latest-tag.outputs.GIT_LATEST_TAG }}
+
       - name: Create release
         run: make clean build release
+        env:
+          RELEASE_VERSION: ${{ steps.next-tag.outputs.version }}
 
       - name: Get Pak Name
         id: pak-name
         run: |
-          echo "PAK_NAME=$(jq -r .label config.json)" >> $GITHUB_OUTPUT
+          echo "PAK_NAME=$(jq -r .name pak.json)" >> $GITHUB_OUTPUT
 
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v2.2.3
@@ -69,32 +85,20 @@ jobs:
       - name: Get Pak Name
         id: pak-name
         run: |
-          echo "PAK_NAME=$(jq -r .label config.json)" >> $GITHUB_OUTPUT
+          echo "PAK_NAME=$(jq -r .name pak.json)" >> $GITHUB_OUTPUT
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4.2.1
+        uses: actions/download-artifact@v4.3.0
         with:
           name: "${{ steps.pak-name.outputs.PAK_NAME }}.pak.zip"
           path: "dist"
-      
+
       - name: Validate Artifact exists
         run: |
           if [ ! -f "dist/${{ steps.pak-name.outputs.PAK_NAME }}.pak.zip" ]; then
             echo "Artifact does not exist"
             exit 1
           fi
-
-      - name: Get Latest Tag
-        id: latest-tag
-        run: |
-          echo GIT_LATEST_TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)")" >>"$GITHUB_OUTPUT"
-
-      - name: Compute Next Tag
-        id: next-tag
-        uses: docker://ghcr.io/dokku/semver-generator:latest
-        with:
-          bump: ${{ github.event.inputs.bump_type }}
-          input: ${{ steps.latest-tag.outputs.GIT_LATEST_TAG }}
 
       - name: Create and Push Tag
         run: |
@@ -103,7 +107,7 @@ jobs:
           git tag "$GIT_NEXT_TAG"
           git push origin "$GIT_NEXT_TAG"
         env:
-          GIT_NEXT_TAG: ${{ steps.next-tag.outputs.version }}
+          GIT_NEXT_TAG: ${{ needs.build.outputs.next-tag }}
 
       - name: Release
         uses: softprops/action-gh-release@v2.2.2
@@ -111,4 +115,4 @@ jobs:
           files: dist/*
           generate_release_notes: true
           make_latest: "true"
-          tag_name: ${{ steps.next-tag.outputs.version }}
+          tag_name: ${{ needs.build.outputs.next-tag }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PAK_NAME := $(shell jq -r .label config.json)
+PAK_NAME := $(shell jq -r .name pak.json)
 
 ARCHITECTURES := arm arm64
 PLATFORMS := rg35xxplus tg5040
@@ -32,4 +32,12 @@ release: build
 	mkdir -p dist
 	git archive --format=zip --output "dist/$(PAK_NAME).pak.zip" HEAD
 	while IFS= read -r file; do zip -r "dist/$(PAK_NAME).pak.zip" "$$file"; done < .gitarchiveinclude
+	jq '.version = "$(RELEASE_VERSION)"' pak.json > pak.json.tmp
+	mv pak.json.tmp pak.json
+	zip -r "dist/$(PAK_NAME).pak.zip" pak.json
 	ls -lah dist
+
+push: release
+	rm -rf "dist/$(PAK_NAME).pak"
+	cd dist && unzip "$(PAK_NAME).pak.zip" -d "$(PAK_NAME).pak"
+	adb push "dist/$(PAK_NAME).pak/." "$(PUSH_SDCARD_PATH)/$(PAK_FOLDER)/$(PUSH_PLATFORM)/$(PAK_NAME).pak"

--- a/config.json
+++ b/config.json
@@ -1,9 +1,0 @@
-{
-    "label": "Gallery",
-    "launch": "launch.sh",
-    "description": "Launches a Gallery to view screenshots",
-    "platforms": [
-        "rg35xxplus",
-        "tg5040"
-    ]
-}

--- a/pak.json
+++ b/pak.json
@@ -1,0 +1,14 @@
+{
+    "name": "Gallery",
+    "type": "TOOL",
+    "description": "Launches a Gallery to view screenshots",
+    "author": "josegonzalez",
+    "repo_url": "https://github.com/josegonzalez/minui-gallery-pak",
+    "release_filename": "Gallery.pak.zip",
+    "platforms": [
+        "rg35xxplus",
+        "tg5040"
+    ],
+    "launch": "launch.sh",
+    "version": "latest"
+}


### PR DESCRIPTION
This change allows the paks to be managed by the nextui-pak-store. MinUI doesn't consume the config.json, and that was a standard I used internally, so changing to pak.json should be fine.

Also add the version number to the pak.json stored in the release zip.